### PR TITLE
fix typo in import_item table

### DIFF
--- a/openlibrary/core/schema.py
+++ b/openlibrary/core/schema.py
@@ -83,7 +83,7 @@ def get_schema():
     CREATE TABLE import_item (
         id serial primary key,
         batch_id integer references import_batch,
-        added_time timestamp without time zome default (current_timestamp at time zone 'utc'),
+        added_time timestamp without time zone default (current_timestamp at time zone 'utc'),
         import_time timestamp without time zone,
         status text default 'pending',
         error text,


### PR DESCRIPTION
I noticed this typo was causing errors on Travis CI which were being ignored, see https://travis-ci.org/internetarchive/openlibrary/builds/214360046#L792
I'm not sure of the production implications of this change, or whether the production db has the same problem and needs to be fixed by some other mechanism?